### PR TITLE
Use music-metadata?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/mime-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.11.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
@@ -989,6 +995,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "file-type": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-12.4.0.tgz",
+      "integrity": "sha512-WTvyKq8yjtNmUtVAD8LGcTkvtCdJglM6ks2HTqEClm6+65XTqM6MoZYA1Vtra50DLRWLiM38fEs1y56f5VhnUA=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -2100,14 +2111,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
-    "jsmediatags": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/jsmediatags/-/jsmediatags-3.9.2.tgz",
-      "integrity": "sha512-kbdYK/Jka44aBfIs4+pvu5hJfVqmzcRLs3oT25q94QsT8D6fX31RSZ5nQ+FP/zvmPfllKYZpzw/uoWOE5DmN6Q==",
-      "requires": {
-        "xhr2": "^0.1.4"
-      }
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -2337,6 +2340,39 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "music-metadata": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-4.8.4.tgz",
+      "integrity": "sha512-Di6EVUG7BT/acgr7U+b2U89DtzQRLOV5LvjsnPzY0riqEDqio3lCJ15QNDoG7dQfT5bV0VL/ocLk7tUeh9fubA==",
+      "requires": {
+        "content-type": "^1.0.4",
+        "debug": "^4.1.0",
+        "file-type": "^12.4.0",
+        "media-typer": "^1.1.0",
+        "strtok3": "^3.0.6",
+        "token-types": "^1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "media-typer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+          "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "nan": {
       "version": "2.14.0",
@@ -3265,6 +3301,31 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
+    "strtok3": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-3.0.6.tgz",
+      "integrity": "sha512-suDDUDB4vP0YN6xuPGDY3DZAITzzNc2kNZ+TSshi5UsD6lc/XgRAx6bdN8DD67382lxdgBNFfzLUmpRGqr5EuA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "then-read-stream": "^2.0.8",
+        "token-types": "^1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3296,6 +3357,11 @@
       "requires": {
         "execa": "^0.7.0"
       }
+    },
+    "then-read-stream": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/then-read-stream/-/then-read-stream-2.0.8.tgz",
+      "integrity": "sha512-OIQn3/zF2J/gp6mAQTbBb1AR+3yoSRqjaij0gGnEUcTl93T840mWIZ9sJWwubjwP7VUDwJpT+Tdl7T9RrQmMlw=="
     },
     "timed-out": {
       "version": "4.0.1",
@@ -3360,6 +3426,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "token-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-1.1.0.tgz",
+      "integrity": "sha512-CgM5GmtJaZ+uTOiZHzs9pwUa/udjEVl/cxQ2KGpl88Hh7k71sdBz9j95dYjx83O68B6CGvefm29l4rBZq1PeuQ=="
     },
     "touch": {
       "version": "3.1.0",
@@ -3682,11 +3753,6 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
-    },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
     },
     "yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,15 @@
     "commander": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "jsmediatags": "^3.9.2",
     "lowdb": "^1.0.0",
+    "mime-types": "^2.1.24",
+    "music-metadata": "^4.8.4",
     "nosql": "^6.1.0",
     "sqlite3": "^4.1.0",
     "tingodb": "^0.6.1"
   },
   "devDependencies": {
+    "@types/mime-types": "^2.1.0",
     "@types/node": "^12.11.1",
     "nodemon": "^1.19.4",
     "ts-node": "^8.4.1",

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import { promisify } from 'util';
 import crypto from 'crypto';
 import Tingo from 'tingodb';
+import { ITrackMetadata } from './MusicIndexer';
+import * as mime from 'mime-types';
 
 const TingoDB = Tingo().Db;
 const fsWriteFile = promisify(fs.writeFile);
@@ -48,27 +50,15 @@ class Store {
             .digest(encoding || 'hex');
     }
 
-    private getFileExt(format: string) {
-        if (!format || format.trim().length === 0) {
-            // console.log('getFileExt: A - ', format);
-            return '.unkown';
-        } else if (format.indexOf('/') > - 1) {
-            return this.typeMap[format];
-        } else {
-            // console.log('getFileExt: B - ', format);
-            return `.${format.toLowerCase()}`;
-        }
-    }
-
     private async writeImage(name, data) {
         const imagePath = path.join(this.coversPath, name);
         fsWriteFile(imagePath, data);
     }
 
-    async addTrack(trackMetadata) {
-        if (trackMetadata.picture) {
-            const imgData = Buffer.from(trackMetadata.picture.data);
-            let ext = this.getFileExt(trackMetadata.picture.format);
+    async addTrack(trackMetadata: ITrackMetadata) {
+        if (trackMetadata.picture && trackMetadata.picture.length >= 1) {
+            const imgData = Buffer.from(trackMetadata.picture[0].data);
+            const ext = mime.extension(trackMetadata.picture[0].format);
             const checksum = await this.generateChecksum(imgData);
             const filename = `${checksum}${ext}`;
 


### PR DESCRIPTION
Please give [music-metadata](https://github.com/Borewit/music-metadata) a try, it is designed for this:
* support for promises
* TypeScript definitions build in
* Works with any audio file and metadata header
* Most advanced and [frequently used](https://npmcharts.com/compare/music-metadata,jsmediatags,musicmetadata,node-id3,music-metadata-browser,id3-parser,mp4-parser,parse-audio-metadata,music-tags,id3,read-id3-tags,stream-id3,wav-file-info,audio-metadata?start=1000&interval=30) JavaScript metadata parser.

In this PR:
* switched to [music-metadata](https://github.com/Borewit/music-metadata)
* let [mime-types](https://github.com/jshttp/mime-types) determine the extension for the cover art

I have not tested the changes.

Good luck with your project, let me know if you experience any issue or face great success ;-)